### PR TITLE
chore: update/fix deps (5.0)

### DIFF
--- a/debian10/Dockerfile
+++ b/debian10/Dockerfile
@@ -15,10 +15,10 @@ RUN apt-get update && apt-get install -y \
     git \
     jq \
     libffi-dev \
-    libkrb5 \
+    libkrb5-3 \
     libkrb5-dev \
     libncurses5-dev \
-    libsasl2 \
+    libsasl2-2 \
     libsasl2-dev \
     libsasl2-modules-gssapi-mit \
     libssl-dev \

--- a/debian11/Dockerfile
+++ b/debian11/Dockerfile
@@ -15,10 +15,10 @@ RUN apt-get update && apt-get install -y \
     git \
     jq \
     libffi-dev \
-    libkrb5 \
+    libkrb5-3 \
     libkrb5-dev \
     libncurses5-dev \
-    libsasl2 \
+    libsasl2-2 \
     libsasl2-dev \
     libsasl2-modules-gssapi-mit \
     libssl-dev \

--- a/debian9/Dockerfile
+++ b/debian9/Dockerfile
@@ -15,10 +15,10 @@ RUN apt-get update && apt-get install -y \
     git \
     jq \
     libffi-dev \
-    libkrb5 \
+    libkrb5-3 \
     libkrb5-dev \
     libncurses5-dev \
-    libsasl2 \
+    libsasl2-2 \
     libsasl2-dev \
     libsasl2-modules-gssapi-mit \
     libssl-dev \

--- a/el7/Dockerfile
+++ b/el7/Dockerfile
@@ -20,8 +20,6 @@ RUN yum install -y autoconf \
                    zlib-devel
 
 RUN yum install -y \
-    libsasl2 \
-    libsasl2-dev \
     krb5-workstation \
     cyrus-sasl-devel \
     cyrus-sasl \

--- a/el8/Dockerfile
+++ b/el8/Dockerfile
@@ -26,8 +26,6 @@ RUN yum install -y autoconf \
                    zip
 
 RUN yum install -y \
-    libsasl2 \
-    libsasl2-dev \
     krb5-workstation \
     cyrus-sasl-devel \
     cyrus-sasl \

--- a/raspbian10/Dockerfile
+++ b/raspbian10/Dockerfile
@@ -12,10 +12,10 @@ RUN apt-get update && apt-get install -y \
     gcc \
     jq \
     libffi-dev \
-    libkrb5 \
+    libkrb5-3 \
     libkrb5-dev \
     libncurses5-dev \
-    libsasl2 \
+    libsasl2-2 \
     libsasl2-dev \
     libsasl2-modules-gssapi-mit \
     libssl-dev \

--- a/raspbian9/Dockerfile
+++ b/raspbian9/Dockerfile
@@ -12,10 +12,10 @@ RUN apt-get update && apt-get install -y \
     gcc \
     jq  \
     libffi-dev \
-    libkrb5 \
+    libkrb5-3 \
     libkrb5-dev \
     libncurses5-dev \
-    libsasl2 \
+    libsasl2-2 \
     libsasl2-dev \
     libsasl2-modules-gssapi-mit \
     libssl-dev \

--- a/ubuntu16.04/Dockerfile
+++ b/ubuntu16.04/Dockerfile
@@ -16,10 +16,10 @@ RUN apt-get update && apt-get install -y \
     gcc \
     jq \
     libffi-dev \
-    libkrb5 \
+    libkrb5-3 \
     libkrb5-dev \
     libncurses5-dev \
-    libsasl2 \
+    libsasl2-2 \
     libsasl2-dev \
     libsasl2-modules-gssapi-mit \
     libssl-dev \

--- a/ubuntu18.04/Dockerfile
+++ b/ubuntu18.04/Dockerfile
@@ -18,10 +18,10 @@ RUN apt-get update && apt-get install -y \
     git \
     jq \
     libffi-dev \
-    libkrb5 \
+    libkrb5-3 \
     libkrb5-dev \
     libncurses5-dev \
-    libsasl2 \
+    libsasl2-2 \
     libsasl2-dev \
     libsasl2-modules-gssapi-mit \
     libssl-dev \

--- a/ubuntu20.04/Dockerfile
+++ b/ubuntu20.04/Dockerfile
@@ -20,10 +20,10 @@ RUN apt-get update && apt-get install -y \
     git \
     jq \
     libffi-dev \
-    libkrb5 \
+    libkrb5-3 \
     libkrb5-dev \
     libncurses5-dev \
-    libsasl2 \
+    libsasl2-2 \
     libsasl2-dev \
     libsasl2-modules-gssapi-mit \
     libssl-dev \


### PR DESCRIPTION
Port of #40 .

Apparently, some packages had their name changed, or they don't exist
with that name in their repos (like `libsasl` in RockyLinux).