### PR TITLE
chore: update 24.2.1 version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,4 +4,4 @@ OTP versions for emqx/otp.git:
 
 + OTP-23.3.4.9-3
 + OTP-24.1.5-3
-+ OTP-24.2.1-ocsp-3
++ OTP-24.2.1-2


### PR DESCRIPTION
Now that the OCSP + CRL features are merged into our 24.2.1 fork, we
can use that.