### PR TITLE
chore: bump OTP version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,8 +2,8 @@ New EMQX 5.0 Builder is Released
 
 OTP versions from emqx/otp.git:
 
-+ OTP-23.3.4.9-4
-+ OTP-24.2.1-1
++ OTP-23.3.4.18-1
++ OTP-24.3.4.2-1
 
 Elixir versions from elixir-lang/elixir.git:
 


### PR DESCRIPTION
bump OTP version due to https://cve.report/CVE-2022-37026