### PR TITLE
fix: install emqtt-bench binaries into local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,6 @@ ARG EMQTT_BENCH_REF
 COPY get-emqtt-bench.sh /get-emqtt-bench.sh
 RUN /get-emqtt-bench.sh "${EMQTT_BENCH_REF:-0.4.7}"
 
-ENV PATH="/tools/emqtt-bench:$PATH"
-
 ARG LUX_REF
 ENV LUX_REF=${LUX_REF:-lux-2.6}
 

--- a/get-emqtt-bench.sh
+++ b/get-emqtt-bench.sh
@@ -26,5 +26,9 @@ case "$SYSTEM" in
         ;;
 esac
 
-git clone --depth=1 --branch="${VSN}" https://github.com/emqx/emqtt-bench.git /tools/emqtt-bench
-make REBAR=/usr/local/bin/rebar3 -C /tools/emqtt-bench
+git clone --depth=1 --branch="${VSN}" https://github.com/emqx/emqtt-bench.git /emqtt-bench
+make REBAR=/usr/local/bin/rebar3 -C /emqtt-bench
+cp -v /emqtt-bench/emqtt_bench /emqtt-bench/*.so /usr/local/bin/
+
+# cleanup
+rm -rf /emqtt-bench


### PR DESCRIPTION
Instead of poisoning `$PATH` with emqtt-bench directory. Since it has `rebar3` inside which wins over installed one.

```
❯ docker run --rm -it ghcr.io/emqx/emqx-builder/5.0-24:1.13.4-25.1.2-2-ubuntu20.04
root@9bdb61782d71:/# which rebar3
/tools/emqtt-bench/rebar3
```