### PR TITLE
chore: use latest git in debian9, ubuntu 16 and 18

### DIFF
--- a/amzn2/Dockerfile
+++ b/amzn2/Dockerfile
@@ -1,16 +1,12 @@
 ARG BUILD_FROM=amazonlinux:2
 FROM ${BUILD_FROM}
 
-RUN yum update -y && yum install -y \
-    autoconf \
-    automake \
-    bison \
+RUN yum update -y
+
+RUN yum groupinstall -y "Development Tools" && yum install -y \
     curl \
-    flex \
     git \
     jq \
-    libatomic \
-    libtool \
     ncurses-devel \
     openssl \
     openssl-devel \
@@ -19,11 +15,9 @@ RUN yum update -y && yum install -y \
     systemd \
     unixODBC \
     unixODBC-devel \
-    unzip \
     vim \
     wget \
     which \
-    zip \
     krb5-workstation \
     cyrus-sasl-devel \
     cyrus-sasl \
@@ -35,11 +29,12 @@ RUN yum install -y \
     krb5-server \
     expect
 
-RUN yum groupinstall -y "Development Tools"
+ADD *.sh /
 
 WORKDIR /
 
-COPY get-cmake.sh /get-cmake.sh
+RUN yum remove -y automake && /get-automake.sh
+
 RUN /get-cmake.sh build
 
 RUN alternatives --install /usr/bin/python python /usr/bin/python2 1 && \

--- a/amzn2/Dockerfile
+++ b/amzn2/Dockerfile
@@ -29,7 +29,7 @@ RUN yum install -y \
     krb5-server \
     expect
 
-ADD *.sh /
+ADD get-cmake.sh get-automake.sh  /
 
 WORKDIR /
 
@@ -48,7 +48,8 @@ RUN alternatives --install /usr/bin/python python /usr/bin/python2 1 && \
 # cleanup
 RUN yum clean packages && \
     rm -rf /tmp/* && \
-    rm -rf /var/tmp/*
+    rm -rf /var/tmp/* && \
+    rm /get-cmake.sh /get-automake.sh
 
 # Elixir complains if runs without UTF-8
 ENV LC_ALL=C.UTF-8

--- a/debian9/Dockerfile
+++ b/debian9/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get install -y \
     krb5-admin-server \
     expect
 
-ADD *.sh /
+ADD get-git.sh get-cmake.sh /
 
 WORKDIR /
 
@@ -73,7 +73,8 @@ RUN /get-cmake.sh build
 
 # cleanup
 RUN apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && rm /get-git.sh /get-cmake.sh
 
 # Elixir complains if runs without UTF-8
 ENV LC_ALL=C.UTF-8

--- a/debian9/Dockerfile
+++ b/debian9/Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get update && apt-get install -y \
     libtool \
     make \
     procps \
+    unixodbc \
+    unixodbc-dev \
     unzip \
     vim \
     wget \
@@ -41,12 +43,15 @@ RUN apt-get install -y \
     krb5-admin-server \
     expect
 
-RUN apt-get update &&  apt-get install -y unixodbc unixodbc-dev
+ADD *.sh /
 
 WORKDIR /
 
-RUN apt-get install -y gcc make zlib1g-dev libffi-dev libssl-dev \
-    && wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
+RUN apt-get install -y libcurl4-openssl-dev \
+    && /get-git.sh \
+    && git --version
+
+RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
     && tar xvf Python-3.7.4.tgz \
     && cd Python-3.7.4 \
     && echo "_socket socketmodule.c" >> Modules/Setup.dist \
@@ -57,17 +62,18 @@ RUN apt-get install -y gcc make zlib1g-dev libffi-dev libssl-dev \
     && rm -rf /usr/bin/python3 /usr/bin/python \
     && ln -s /usr/local/python3.7.4/bin/python3.7 /usr/bin/python3 \
     && ln -s /usr/local/python3.7.4/bin/python3.7 /usr/bin/python
+
 RUN curl -k -L -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py \
     && python /tmp/get-pip.py \
     && python3 /tmp/get-pip.py
+
 ENV PATH=/usr/local/python3.7.4/bin:$PATH
 
-COPY get-cmake.sh /get-cmake.sh
 RUN /get-cmake.sh build
 
 # cleanup
-RUN apt-get clean\
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Elixir complains if runs without UTF-8
 ENV LC_ALL=C.UTF-8

--- a/el7/Dockerfile
+++ b/el7/Dockerfile
@@ -34,33 +34,24 @@ RUN yum install -y \
     krb5-server \
     expect
 
-RUN yum groupinstall -y "Development Tools"
+RUN yum groupinstall -y "Development Tools" \
+    && yum install -y centos-release-scl \
+    && yum install -y devtoolset-8-gcc devtoolset-8-gcc-c++
 
-RUN yum install -y centos-release-scl
-RUN yum install -y devtoolset-8-gcc devtoolset-8-gcc-c++
-
-ADD install-openssl11.sh /install-openssl11.sh
-RUN /install-openssl11.sh
+ADD *.sh /
 
 WORKDIR /
 
-ENV GIT_VERSION=2.38.1 DEVELOPER_CFLAGS='-std=gnu99'
+RUN /install-openssl11.sh
+
 # - have to uninstall stock git to cleanup all git backend files,
 #   otherwise git from the newer version may encounter
 #   an error like "bogus format in GIT_CONFIG_PARAMETERS"
 # - gnu99 flag is to address https://gitlab.com/gitlab-org/omnibus-gitlab/-/merge_requests/5948
 # - libcurl-devel is needed to support clone from https remotes
-RUN yum remove -y git \
+RUN yum remove -y git* \
     && yum install -y libcurl-devel \
-    && curl -L -o /tmp/git.tar.gz "https://github.com/git/git/archive/v${GIT_VERSION}.tar.gz" \
-    && tar zxf /tmp/git.tar.gz -C /tmp \
-    && cd "/tmp/git-${GIT_VERSION}/" \
-    && make configure \
-    && ./configure --prefix=/usr \
-    && make all \
-    && make install \
-    && cd / \
-    && rm -rf /tmp/git.tar.gz "/tmp/git-${GIT_VERSION}/" \
+    && env DEVELOPER_CFLAGS='-std=gnu99' /get-git.sh \
     && git --version
 
 RUN curl -L -o /tmp/automake-1.14.tar.gz http://ftp.gnu.org/gnu/automake/automake-1.14.tar.gz \
@@ -72,7 +63,6 @@ RUN curl -L -o /tmp/automake-1.14.tar.gz http://ftp.gnu.org/gnu/automake/automak
     && make install \
     && automake --version
 
-COPY get-cmake.sh /get-cmake.sh
 RUN env OPENSSL_ROOT_DIR=/usr/local/openssl /get-cmake.sh build
 
 # We have to reinstall `glibc-common` after removing the override just

--- a/el7/Dockerfile
+++ b/el7/Dockerfile
@@ -38,7 +38,7 @@ RUN yum groupinstall -y "Development Tools" \
     && yum install -y centos-release-scl \
     && yum install -y devtoolset-8-gcc devtoolset-8-gcc-c++
 
-ADD *.sh /
+ADD install-openssl11.sh get-git.sh get-automake.sh get-cmake.sh /
 
 WORKDIR /
 
@@ -76,7 +76,8 @@ RUN alternatives --install /usr/bin/python python /usr/bin/python2 1 && \
 # cleanup
 RUN yum clean packages && \
     rm -rf /tmp/* && \
-    rm -rf /var/tmp/*
+    rm -rf /var/tmp/* && \
+    rm /install-openssl11.sh /get-git.sh /get-automake.sh /get-cmake.sh
 
 ENV BASH_ENV=/opt/rh/devtoolset-8/enable \
     ENV=/opt/rh/devtoolset-8/enable \

--- a/el7/Dockerfile
+++ b/el7/Dockerfile
@@ -54,14 +54,7 @@ RUN yum remove -y git* \
     && env DEVELOPER_CFLAGS='-std=gnu99' /get-git.sh \
     && git --version
 
-RUN curl -L -o /tmp/automake-1.14.tar.gz http://ftp.gnu.org/gnu/automake/automake-1.14.tar.gz \
-    && tar -zxvf /tmp/automake-1.14.tar.gz -C /tmp \
-    && cd /tmp/automake-1.14 \
-    && ./bootstrap.sh \
-    && ./configure \
-    && make \
-    && make install \
-    && automake --version
+RUN /get-automake.sh
 
 RUN env OPENSSL_ROOT_DIR=/usr/local/openssl /get-cmake.sh build
 

--- a/get-automake.sh
+++ b/get-automake.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+AUTOMAKE_VERSION="${AUTOMAKE_VERSION:-1.14}"
+
+PACKAGE="automake-$AUTOMAKE_VERSION"
+ARCHIVE="$PACKAGE.tar.gz"
+URL="http://ftp.gnu.org/gnu/automake/$ARCHIVE"
+curl --silent --show-error -fkL -o "/tmp/$ARCHIVE" "$URL"
+tar -zxvf "/tmp/$ARCHIVE" -C /tmp
+cd "/tmp/$PACKAGE"
+./bootstrap.sh
+./configure
+make
+make install
+automake --version
+
+cd /
+rm -rf "/tmp/$ARCHIVE" "/tmp/$PACKAGE"

--- a/get-git.sh
+++ b/get-git.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+GIT_VERSION="${GIT_VERSION:-2.38.1}"
+
+URL="https://github.com/git/git/archive/refs/tags/v${GIT_VERSION}.tar.gz"
+
+## download and untar
+cd /
+curl --silent --show-error -fkL "$URL" -o "git.tar.gz"
+tar -zxf git.tar.gz
+
+## build
+cd "/git-${GIT_VERSION}/"
+
+make configure
+./configure --prefix=/usr
+make all
+make install
+
+## cleanup
+cd /
+rm -rf git.tar.gz "/git-${GIT_VERSION}/"

--- a/ubuntu16.04/Dockerfile
+++ b/ubuntu16.04/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update && apt-get install -y \
     libtool \
     make \
     software-properties-common \
+    unixodbc \
+    unixodbc-dev \
     unzip \
     vim \
     wget \
@@ -42,24 +44,15 @@ RUN apt-get install -y \
     krb5-admin-server \
     expect
 
-RUN apt-get update &&  apt-get install -y unixodbc unixodbc-dev
+ADD *.sh /
 
 WORKDIR /
 
-RUN apt-get update && apt-get install -y libcurl4-openssl-dev \
-    && wget https://github.com/git/git/archive/v2.17.1.tar.gz \
-    && tar xzvf v2.17.1.tar.gz \
-    && cd git-2.17.1/ \
-    && make configure \
-    && ./configure \
-    && make \
-    && make install \
-    && cd / \
-    && rm -rf git-2.17.1 \
+RUN apt-get install -y libcurl4-openssl-dev \
+    && /get-git.sh \
     && git --version
 
-RUN apt-get install -y gcc make zlib1g-dev libffi-dev libssl-dev \
-    && wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
+RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
     && tar xvf Python-3.7.4.tgz \
     && cd Python-3.7.4 \
     && echo "_socket socketmodule.c" >> Modules/Setup.dist \
@@ -70,21 +63,21 @@ RUN apt-get install -y gcc make zlib1g-dev libffi-dev libssl-dev \
     && rm -rf /usr/bin/python3 /usr/bin/python \
     && ln -s /usr/local/python3.7.4/bin/python3.7 /usr/bin/python3 \
     && ln -s /usr/local/python3.7.4/bin/python3.7 /usr/bin/python
+
 RUN sed -i 's/python3/python2.7/1' /usr/bin/lsb_release \
     && curl -k -L -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py \
     && python /tmp/get-pip.py \
     && python3 /tmp/get-pip.py
+
 ENV PATH=/usr/local/python3.7.4/bin:$PATH
 
-COPY get-cmake.sh /get-cmake.sh
 RUN /get-cmake.sh build
 
-RUN apt-get clean\
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Elixir complains if runs without UTF-8
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-WORKDIR /
 CMD [ "/bin/bash" ]

--- a/ubuntu16.04/Dockerfile
+++ b/ubuntu16.04/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get install -y \
     krb5-admin-server \
     expect
 
-ADD *.sh /
+ADD get-git.sh get-cmake.sh /
 
 WORKDIR /
 
@@ -74,7 +74,8 @@ ENV PATH=/usr/local/python3.7.4/bin:$PATH
 RUN /get-cmake.sh build
 
 RUN apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && rm /get-git.sh /get-cmake.sh
 
 # Elixir complains if runs without UTF-8
 ENV LC_ALL=C.UTF-8

--- a/ubuntu18.04/Dockerfile
+++ b/ubuntu18.04/Dockerfile
@@ -31,6 +31,8 @@ RUN apt-get update && apt-get install -y \
     libtool \
     make \
     software-properties-common \
+    unixodbc \
+    unixodbc-dev \
     unzip \
     vim \
     wget \
@@ -44,13 +46,11 @@ RUN apt-get install -y \
     krb5-admin-server \
     expect
 
-RUN cmake --version
-RUN apt-get update &&  apt-get install -y unixodbc unixodbc-dev
+ADD *.sh /
 
 WORKDIR /
 
-RUN apt-get install -y gcc make zlib1g-dev libffi-dev libssl-dev \
-    && wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
+RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
     && tar xvf Python-3.7.4.tgz \
     && cd Python-3.7.4 \
     && echo "_socket socketmodule.c" >> Modules/Setup.dist \
@@ -61,22 +61,22 @@ RUN apt-get install -y gcc make zlib1g-dev libffi-dev libssl-dev \
     && rm -rf /usr/bin/python3 /usr/bin/python \
     && ln -s /usr/local/python3.7.4/bin/python3.7 /usr/bin/python3 \
     && ln -s /usr/local/python3.7.4/bin/python3.7 /usr/bin/python
+
 RUN sed -i 's/python3/python2.7/1' /usr/bin/lsb_release \
     && curl -k -L -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py \
     && python /tmp/get-pip.py \
     && python3 /tmp/get-pip.py
+
 ENV PATH=/usr/local/python3.7.4/bin:$PATH
 
-# cleanup
-RUN apt-get clean\
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-COPY get-cmake.sh /get-cmake.sh
 RUN /get-cmake.sh build
+
+# cleanup
+RUN apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Elixir complains if runs without UTF-8
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-WORKDIR /
 CMD [ "/bin/bash" ]

--- a/ubuntu18.04/Dockerfile
+++ b/ubuntu18.04/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get install -y \
     krb5-admin-server \
     expect
 
-ADD *.sh /
+ADD get-cmake.sh /
 
 WORKDIR /
 
@@ -73,7 +73,8 @@ RUN /get-cmake.sh build
 
 # cleanup
 RUN apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && rm /get-cmake.sh
 
 # Elixir complains if runs without UTF-8
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
Otherwise Github actions refuse to use clone which leads to rebar3 not being able to detect version from git tag and we get situation like this: https://github.com/emqx/emqtt-bench/releases/tag/0.4.10.

Other changes:
* resurrected get-git.sh since it's now used by more than one Dockerfile
* reduced number of layers in affected images by consolidated packages installation and by adding all available shell scripts in one command
* add automake 1.14 in amzn2 instead of stock 1.13 one, and remove manual installation of packages covered by "Development Tools" group