### PR TITLE
chore: bump OTP-24 builder to 24.3.4.2-3 and OTP-25 to 25.1.2-3

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,8 +2,8 @@ New EMQX 5.0 Builder is Released
 
 OTP versions from emqx/otp.git:
 
-+ OTP-24.3.4.2-2
-+ OTP-25.1.2-2
++ OTP-24.3.4.2-3
++ OTP-25.1.2-3
 
 Elixir versions from elixir-lang/elixir.git:
 


### PR DESCRIPTION
Relates to: https://emqx.atlassian.net/browse/EMQX-9111
OTP 24.3.4.2-3 and 25.1.2-3 implement `mnesia_hook:unregister_hook/1`