### PR TITLE
feat: add Amazon Linux 2023

### DIFF
--- a/.github/workflows/base.yaml
+++ b/.github/workflows/base.yaml
@@ -30,6 +30,7 @@ jobs:
           - [el8         , "linux/amd64,linux/arm64"]
           - [el7         , "linux/amd64,linux/arm64"]
           - [amzn2       , "linux/amd64,linux/arm64"]
+          - [amzn2023    , "linux/amd64,linux/arm64"]
           - [raspbian10  , "linux/arm64"]
           - [raspbian9   , "linux/arm64"]
           - [alpine3.15.1, "linux/amd64,linux/arm64"]

--- a/.github/workflows/base.yaml
+++ b/.github/workflows/base.yaml
@@ -31,8 +31,6 @@ jobs:
           - [el7         , "linux/amd64,linux/arm64"]
           - [amzn2       , "linux/amd64,linux/arm64"]
           - [amzn2023    , "linux/amd64,linux/arm64"]
-          - [raspbian10  , "linux/arm64"]
-          - [raspbian9   , "linux/arm64"]
           - [alpine3.15.1, "linux/amd64,linux/arm64"]
 
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,8 +49,6 @@ jobs:
           - [el7         , "linux/amd64,linux/arm64"]
           - [amzn2       , "linux/amd64,linux/arm64"]
           - [amzn2023    , "linux/amd64,linux/arm64"]
-          - [raspbian10  , "linux/arm64"]
-          - [raspbian9   , "linux/arm64"]
           - [alpine3.15.1, "linux/amd64,linux/arm64"]
 
     steps:
@@ -115,8 +113,6 @@ jobs:
           - [el7         , "linux/amd64,linux/arm64"]
           - [amzn2       , "linux/amd64,linux/arm64"]
           - [amzn2023    , "linux/amd64,linux/arm64"]
-          - [raspbian10  , "linux/arm64"]
-          - [raspbian9   , "linux/arm64"]
           - [alpine3.15.1, "linux/amd64,linux/arm64"]
 
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,8 +48,9 @@ jobs:
           - [el8         , "linux/amd64,linux/arm64"]
           - [el7         , "linux/amd64,linux/arm64"]
           - [amzn2       , "linux/amd64,linux/arm64"]
-          # - [raspbian10  , "linux/arm64"]
-          # - [raspbian9   , "linux/arm64"]
+          - [amzn2023    , "linux/amd64,linux/arm64"]
+          - [raspbian10  , "linux/arm64"]
+          - [raspbian9   , "linux/arm64"]
           - [alpine3.15.1, "linux/amd64,linux/arm64"]
 
     steps:
@@ -113,6 +114,7 @@ jobs:
           - [el8         , "linux/amd64,linux/arm64"]
           - [el7         , "linux/amd64,linux/arm64"]
           - [amzn2       , "linux/amd64,linux/arm64"]
+          - [amzn2023    , "linux/amd64,linux/arm64"]
           - [raspbian10  , "linux/arm64"]
           - [raspbian9   , "linux/arm64"]
           - [alpine3.15.1, "linux/amd64,linux/arm64"]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,11 +50,6 @@ jobs:
           - [el7         , "linux/amd64,linux/arm64"]
           - [amzn2       , "linux/amd64,linux/arm64"]
           - [amzn2023    , "linux/amd64,linux/arm64"]
-          # Exclude raspbian from tests
-          # It's not one of the target platforms as of now. If this changes it would
-          # probably be a good idea to include it back.
-          # - [raspbian10  , "linux/arm64"]
-          # - [raspbian9   , "linux/arm64"]
           - [alpine3.15.1, "linux/amd64,linux/arm64"]
 
     services:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,7 @@ jobs:
           - [el8         , "linux/amd64,linux/arm64"]
           - [el7         , "linux/amd64,linux/arm64"]
           - [amzn2       , "linux/amd64,linux/arm64"]
+          - [amzn2023    , "linux/amd64,linux/arm64"]
           # Exclude raspbian from tests
           # It's not one of the target platforms as of now. If this changes it would
           # probably be a good idea to include it back.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir /tools
 ARG EMQTT_BENCH_REF
 
 COPY get-emqtt-bench.sh /get-emqtt-bench.sh
-RUN /get-emqtt-bench.sh "${EMQTT_BENCH_REF:-0.4.7}"
+RUN /get-emqtt-bench.sh "${EMQTT_BENCH_REF:-0.4.11}"
 
 ARG LUX_REF
 ENV LUX_REF=${LUX_REF:-lux-2.6}

--- a/amzn2023/Dockerfile
+++ b/amzn2023/Dockerfile
@@ -1,0 +1,36 @@
+ARG BUILD_FROM=amazonlinux:2023
+FROM ${BUILD_FROM}
+
+RUN dnf -y update && \
+    dnf -y groupinstall development && \
+    dnf -y install \
+      cmake \
+      cyrus-sasl \
+      cyrus-sasl-devel \
+      cyrus-sasl-gssapi \
+      expect \
+      jq \
+      krb5-devel \
+      krb5-server \
+      krb5-workstation \
+      libatomic \
+      ncurses-devel \
+      openssl-devel \
+      perl \
+      python3-pip \
+      unixODBC \
+      unixODBC-devel \
+      vim \
+      wget && \
+    dnf clean all && \
+    rm -rf /tmp/* /var/tmp/* /var/cache/dnf
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+WORKDIR /
+
+# Elixir complains if runs without UTF-8
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+CMD [ "/bin/bash" ]

--- a/get-emqtt-bench.sh
+++ b/get-emqtt-bench.sh
@@ -2,7 +2,7 @@
 
 set -xeuo pipefail
 
-VSN="$1"
+VSN="${1:-0.4.11}"
 
 if grep -q -i 'rhel' /etc/os-release; then
     DIST='el'


### PR DESCRIPTION
Note that Amazon Linux 2023 has OpenSSL 3 by default, and 1.1 is not available.

Also removed raspbian everywhere until we can properly support it. Removed and not commented out to avoid potential confusion.