### PR TITLE
1228 upgrade to otp 26.2.1-1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,6 @@ List per major version used by EMQX, quic, rocksdb builds
 
 OTP version from emqx/otp.git:
 
-+ OTP-24.3.4.2-1
 + OTP-25.3.2-2
 + OTP-26.2.1-1
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ OTP version from emqx/otp.git:
 
 + OTP-24.3.4.2-1
 + OTP-25.3.2-2
-+ OTP-26.1.2-3
++ OTP-26.2.1-1
 
 Elixir version from elixir-lang/elixir.git:
 NOTE: Only one version is allowed.


### PR DESCRIPTION
Also stop releasing OTP 24 since 26 is already on EMQX's master branch.

Will bump image tag to 5.3 after merge.