### PR TITLE
chore: bump OTP version to 26.2.5-2

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@ List per major version used by EMQX, quic, rocksdb builds
 OTP version from emqx/otp.git:
 
 + OTP-25.3.2-2
-+ OTP-26.2.5-1
++ OTP-26.2.5-2
 
 Elixir version from elixir-lang/elixir.git:
 NOTE: Only one version is allowed.


### PR DESCRIPTION
https://github.com/emqx/otp/pull/54