### PR TITLE
bump: release emqx-OTP-25.2.5.2-2

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,5 +4,5 @@ OTP version from emqx/otp.git, Elixir version from elixir-lang/elixir.git.
 
 + OTP-24.3.4.2-4,Elixir-1.15.7
 + OTP-25.3.2-2,Elixir-1.15.7
-+ OTP-26.2.5.2-1,Elixir-1.15.7
++ OTP-26.2.5.2-2,Elixir-1.15.7
 + OTP-27.1-1,Elixir-1.17.3


### PR DESCRIPTION
Includes emqx/otp#61.