### PR TITLE
simplify runner labels

### DIFF
--- a/.github/workflows/base.yaml
+++ b/.github/workflows/base.yaml
@@ -44,7 +44,7 @@ jobs:
           - amzn2
           - amzn2023
           - alpine3.15.1
-
+          - alpine3.21.3
 
     env:
       PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/base.yaml
+++ b/.github/workflows/base.yaml
@@ -19,41 +19,36 @@ on:
 jobs:
 
   base:
-    runs-on: ${{ github.repository_owner == 'emqx' && matrix.platform[2] || '["ubuntu-latest"]' }}
+    name: ${{ matrix.platform }} ${{ matrix.arch }}
+    runs-on: ${{ github.repository_owner == 'emqx' && format('aws-ubuntu22.04-{0}', matrix.arch) || (matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04') }}
+
     strategy:
       fail-fast: false
       matrix:
         base_image_vsn:
           - ${{ github.event.inputs.base_image_vsn }}
+        arch:
+          - amd64
+          - arm64
         platform:
-          - [ubuntu24.04, linux/amd64, [self-hosted, linux, x64, ephemeral]]
-          - [ubuntu24.04, linux/arm64, [self-hosted, linux, arm64, ephemeral]]
-          - [ubuntu22.04, linux/amd64, [self-hosted, linux, x64, ephemeral]]
-          - [ubuntu22.04, linux/arm64, [self-hosted, linux, arm64, ephemeral]]
-          - [ubuntu20.04, linux/amd64, [self-hosted, linux, x64, ephemeral]]
-          - [ubuntu20.04, linux/arm64, [self-hosted, linux, arm64, ephemeral]]
-          - [ubuntu18.04, linux/amd64, [self-hosted, linux, x64, ephemeral]]
-          - [ubuntu18.04, linux/arm64, [self-hosted, linux, arm64, ephemeral]]
-          - [debian12, linux/amd64, [self-hosted, linux, x64, ephemeral]]
-          - [debian12, linux/arm64, [self-hosted, linux, arm64, ephemeral]]
-          - [debian11, linux/amd64, [self-hosted, linux, x64, ephemeral]]
-          - [debian11, linux/arm64, [self-hosted, linux, arm64, ephemeral]]
-          - [debian10, linux/amd64, [self-hosted, linux, x64, ephemeral]]
-          - [debian10, linux/arm64, [self-hosted, linux, arm64, ephemeral]]
-          - [el9, linux/amd64, [self-hosted, linux, x64, ephemeral]]
-          - [el9, linux/arm64, [self-hosted, linux, arm64, ephemeral]]
-          - [el8, linux/amd64, [self-hosted, linux, x64, ephemeral]]
-          - [el8, linux/arm64, [self-hosted, linux, arm64, ephemeral]]
-          - [el7, linux/amd64, [self-hosted, linux, x64, ephemeral]]
-          - [el7, linux/arm64, [self-hosted, linux, arm64, ephemeral]]
-          - [amzn2, linux/amd64, [self-hosted, linux, x64, ephemeral]]
-          - [amzn2, linux/arm64, [self-hosted, linux, arm64, ephemeral]]
-          - [amzn2023, linux/amd64, [self-hosted, linux, x64, ephemeral]]
-          - [amzn2023, linux/arm64, [self-hosted, linux, arm64, ephemeral]]
-          - [alpine3.15.1, linux/amd64, [self-hosted, linux, x64, ephemeral]]
-          - [alpine3.15.1, linux/arm64, [self-hosted, linux, arm64, ephemeral]]
+          - ubuntu24.04
+          - ubuntu22.04
+          - ubuntu20.04
+          - ubuntu18.04
+          - debian12
+          - debian11
+          - debian10
+          - el9
+          - el8
+          - el7
+          - amzn2
+          - amzn2023
+          - alpine3.15.1
+
 
     env:
+      PLATFORM: ${{ matrix.platform }}
+      ARCH: ${{ matrix.arch }}
       REGISTRY_IMAGE: ghcr.io/${{ github.repository }}/base-${{ matrix.base_image_vsn }}
 
     steps:
@@ -68,9 +63,7 @@ jobs:
       - name: define base tag
         id: base_tag
         run: |
-          PLATFORM=${{ matrix.platform[1] }}
-          ARCH=${PLATFORM#linux/}
-          echo "tag=${{ matrix.platform[0] }}-${ARCH}" | tee -a $GITHUB_OUTPUT
+          echo "tag=${PLATFORM}-${ARCH}" | tee -a $GITHUB_OUTPUT
       - name: Get cache
         run: aws s3 sync s3://docker-buildx-cache/emqx-builder/${{ steps.base_tag.outputs.tag }} /tmp/.docker-buildx-cache
       - uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
@@ -92,10 +85,10 @@ jobs:
           pull: true
           cache-from: type=local,src=/tmp/.docker-buildx-cache,mode=max
           cache-to: type=local,dest=/tmp/.docker-buildx-cache-new,mode=max
-          platforms: ${{ matrix.platform[1] }}
+          platforms: "linux/${{ matrix.arch }}"
           tags: ${{ steps.base_meta.outputs.tags }}
           labels: ${{ steps.base_meta.outputs.labels }}
-          file: ${{ matrix.platform[0] }}/Dockerfile
+          file: ${{ matrix.platform }}/Dockerfile
           context: .
       - name: Update cache
         run: aws s3 sync --delete /tmp/.docker-buildx-cache-new s3://docker-buildx-cache/emqx-builder/${{ steps.base_tag.outputs.tag }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,8 +14,8 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      otp: ${{ steps.versions.outputs.otp }}
-      elixir: ${{ steps.versions.outputs.elixir }}
+      matrix: ${{ steps.versions.outputs.matrix }}
+      merge_matrix: ${{ steps.versions.outputs.merge_matrix }}
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
     - name: Get target OTP and Elixir versions
@@ -25,9 +25,51 @@ jobs:
         versions="$(grep -E "^\+\sOTP-.*" ./RELEASE.md | \
           sed -E 's/\+\sOTP-([0-9.-]*),Elixir-([0-9.]*).*/{"otp":"\1","elixir":"\2"}/g' | \
           jq -sc .)"
-        echo "$versions"
-        echo "otp=$(echo "$versions" | jq -r '.[].otp' | jq -Rsc 'split("\n")[:-1]')" | tee -a $GITHUB_OUTPUT
-        echo "elixir=$(echo "$versions" | jq -r '.[].elixir' | jq -Rsc 'split("\n")[:-1]')" | tee -a $GITHUB_OUTPUT
+
+        platforms='[
+          "ubuntu24.04",
+          "ubuntu22.04",
+          "ubuntu20.04",
+          "ubuntu18.04",
+          "debian12",   
+          "debian11",   
+          "debian10",   
+          "el9",        
+          "el8",        
+          "el7",         
+          "amzn2",      
+          "amzn2023",   
+          "alpine3.15.1",
+          "alpine3.21.3"
+        ]'
+
+        arhitectures='["amd64", "arm64"]'
+
+        matrix="$(jq -cn \
+          --argjson versions "$versions" \
+          --argjson platforms "$platforms" \
+          --argjson arhitectures "$arhitectures" \
+          '[
+            $versions[] as $version |
+            $platforms[] as $platform |
+            $arhitectures[] as $arch |
+            {
+              base_image_vsn: "5.0",
+              otp: $version.otp,
+              elixir: $version.elixir,
+              platform: $platform,
+              arch: $arch
+            }
+          ]')"
+
+        merge_matrix="$(jq -cn \
+          --argjson matrix "$matrix" \
+          '[
+            $matrix[] | del(.arch)
+          ]')"
+
+        echo "matrix=$matrix" | tee -a $GITHUB_OUTPUT
+        echo "merge_matrix=$merge_matrix" | tee -a $GITHUB_OUTPUT
 
   base:
     name: ${{ matrix.platform }} ${{ matrix.arch }}
@@ -38,26 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image_vsn:
-          - "5.0"
-        arch:
-          - amd64
-          - arm64
-        platform:
-          - ubuntu24.04
-          - ubuntu22.04
-          - ubuntu20.04
-          - ubuntu18.04
-          - debian12
-          - debian11
-          - debian10
-          - el9
-          - el8
-          - el7
-          - amzn2
-          - amzn2023
-          - alpine3.15.1
-          - alpine3.21.3
+        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -112,27 +135,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image_vsn:
-          - "5.0"
-        otp: ${{ fromJSON(needs.prepare.outputs.otp) }}
-        elixir: ${{ fromJSON(needs.prepare.outputs.elixir) }}
-        arch:
-          - amd64
-          - arm64
-        platform:
-          - ubuntu24.04
-          - ubuntu22.04
-          - ubuntu20.04
-          - ubuntu18.04
-          - debian12
-          - debian11
-          - debian10
-          - el9
-          - el8
-          - el7
-          - amzn2
-          - amzn2023
-          - alpine3.15.1
+        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
 
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -222,24 +225,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image_vsn:
-          - "5.0"
-        otp: ${{ fromJSON(needs.prepare.outputs.otp) }}
-        elixir: ${{ fromJSON(needs.prepare.outputs.elixir) }}
-        platform:
-          - ubuntu24.04
-          - ubuntu22.04
-          - ubuntu20.04
-          - ubuntu18.04
-          - debian12
-          - debian11
-          - debian10
-          - el9
-          - el8
-          - el7
-          - amzn2
-          - amzn2023
-          - alpine3.15.1
+        include: ${{ fromJSON(needs.prepare.outputs.merge_matrix) }}
 
     steps:
       - name: Get ref

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,106 +14,50 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.versions.outputs.matrix }}
-      final_matrix: ${{ steps.versions.outputs.final_matrix }}
+      otp: ${{ steps.versions.outputs.otp }}
+      elixir: ${{ steps.versions.outputs.elixir }}
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-    - name: get release versions
+    - name: Get target OTP and Elixir versions
       id: versions
       run: |
         #!/bin/bash
         versions="$(grep -E "^\+\sOTP-.*" ./RELEASE.md | \
           sed -E 's/\+\sOTP-([0-9.-]*),Elixir-([0-9.]*).*/{"otp":"\1","elixir":"\2"}/g' | \
           jq -sc .)"
-
-        platforms='[
-          {"os": "ubuntu24.04", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "ubuntu24.04", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "ubuntu22.04", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "ubuntu22.04", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "ubuntu20.04", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "ubuntu20.04", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "ubuntu18.04", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "ubuntu18.04", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "debian12", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "debian12", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "debian11", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "debian11", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "debian10", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "debian10", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "el9", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "el9", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "el8", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "el8", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "el7", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "el7", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "amzn2", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "amzn2", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "amzn2023", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "amzn2023", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "alpine3.15.1", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "alpine3.15.1", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]}
-        ]'
-
-        final_platforms='[
-          {"os": "ubuntu24.04", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "ubuntu22.04", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "ubuntu20.04", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "ubuntu18.04", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "debian12", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "debian11", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "debian10", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "el9", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "el8", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "el7", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "amzn2", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "amzn2023", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "alpine3.15.1", "runner": ["self-hosted", "linux", "x64", "ephemeral"]}
-        ]'
-
-        matrix="$(jq -cn \
-          --argjson versions "$versions" \
-          --argjson platforms "$platforms" \
-          '[
-            $versions[] as $version |
-            $platforms[] as $platform |
-            {
-              base_image_vsn: "5.0",
-              otp: $version.otp,
-              elixir: $version.elixir,
-              platform: $platform
-            }
-          ]')"
-
-        final_matrix="$(jq -cn \
-          --argjson versions "$versions" \
-          --argjson platforms "$final_platforms" \
-          '[
-            $versions[] as $version |
-            $platforms[] as $platform |
-            {
-              base_image_vsn: "5.0",
-              otp: $version.otp,
-              elixir: $version.elixir,
-              platform: $platform
-            }
-          ]')"
-
-        echo "matrix=$matrix" | tee -a $GITHUB_OUTPUT
-        echo "final_matrix=$final_matrix" | tee -a $GITHUB_OUTPUT
+        echo "$versions"
+        echo "otp=$(echo "$versions" | jq -r '.[].otp' | jq -Rsc 'split("\n")[:-1]')" | tee -a $GITHUB_OUTPUT
+        echo "elixir=$(echo "$versions" | jq -r '.[].elixir' | jq -Rsc 'split("\n")[:-1]')" | tee -a $GITHUB_OUTPUT
 
   base:
-    runs-on: ${{ github.repository_owner == 'emqx' && matrix.platform.runner || '["ubuntu-latest"]' }}
+    name: ${{ matrix.platform }} ${{ matrix.arch }}
+    runs-on: ${{ github.repository_owner == 'emqx' && format('aws-ubuntu22.04-{0}', matrix.arch) || (matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04') }}
     needs:
       - prepare
 
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
-
-    env:
-      REGISTRY_IMAGE: ghcr.io/${{ github.repository }}/base-${{ matrix.base_image_vsn }}
+        base_image_vsn:
+          - "5.0"
+        arch:
+          - amd64
+          - arm64
+        platform:
+          - ubuntu24.04
+          - ubuntu22.04
+          - ubuntu20.04
+          - ubuntu18.04
+          - debian12
+          - debian11
+          - debian10
+          - el9
+          - el8
+          - el7
+          - amzn2
+          - amzn2023
+          - alpine3.15.1
+          - alpine3.21.3
 
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -125,9 +69,9 @@ jobs:
       - name: define base tag
         id: base_tag
         run: |
-          PLATFORM=${{ matrix.platform.arch }}
-          ARCH=${PLATFORM#linux/}
-          echo "tag=${{ matrix.platform.os }}-${ARCH}" | tee -a $GITHUB_OUTPUT
+          echo "tag=${{ matrix.platform }}-${{ matrix.arch }}" | tee -a $GITHUB_OUTPUT
+          echo "image=ghcr.io/${{ github.repository }}/base-${{ matrix.base_image_vsn }}" | tee -a $GITHUB_OUTPUT
+
       - name: Get cache
         run: aws s3 sync s3://docker-buildx-cache/emqx-builder/${{ steps.base_tag.outputs.tag }} /tmp/.docker-buildx-cache
       - uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
@@ -140,7 +84,7 @@ jobs:
       - uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         id: base_meta
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: ${{ steps.base_tag.outputs.image }}
           tags: type=raw,value=${{ steps.base_tag.outputs.tag }}
       - name: Build base image
         id: build
@@ -150,17 +94,17 @@ jobs:
           push: true
           cache-from: type=local,src=/tmp/.docker-buildx-cache,mode=max
           cache-to: type=local,dest=/tmp/.docker-buildx-cache-new,mode=max
-          platforms: ${{ matrix.platform.arch }}
+          platforms: linux/${{ matrix.arch }}
           tags: ${{ steps.base_meta.outputs.tags }}
           labels: ${{ steps.base_meta.outputs.labels }}
-          file: ${{ matrix.platform.os }}/Dockerfile
+          file: ${{ matrix.platform }}/Dockerfile
           context: .
       - name: Update cache
         run: aws s3 sync --delete /tmp/.docker-buildx-cache-new s3://docker-buildx-cache/emqx-builder/${{ steps.base_tag.outputs.tag }}
 
   build:
-    name: ${{ matrix.platform.os }} ${{ matrix.platform.arch }} OTP-${{ matrix.otp }} Elixir-${{ matrix.elixir }}
-    runs-on: ${{ github.repository_owner == 'emqx' && matrix.platform.runner || 'ubuntu-latest' }}
+    name: ${{ matrix.platform }} ${{ matrix.arch }} OTP-${{ matrix.otp }} Elixir-${{ matrix.elixir }}
+    runs-on: ${{ github.repository_owner == 'emqx' && format('aws-ubuntu22.04-{0}', matrix.arch) || (matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04') }}
     needs:
       - prepare
       - base
@@ -168,7 +112,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+        base_image_vsn:
+          - "5.0"
+        otp: ${{ fromJSON(needs.prepare.outputs.otp) }}
+        elixir: ${{ fromJSON(needs.prepare.outputs.elixir) }}
+        arch:
+          - amd64
+          - arm64
+        platform:
+          - ubuntu24.04
+          - ubuntu22.04
+          - ubuntu20.04
+          - ubuntu18.04
+          - debian12
+          - debian11
+          - debian10
+          - el9
+          - el8
+          - el7
+          - amzn2
+          - amzn2023
+          - alpine3.15.1
 
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -193,9 +157,7 @@ jobs:
     - name: define base tag
       id: base_tag
       run: |
-        PLATFORM=${{ matrix.platform.arch }}
-        ARCH="${PLATFORM#linux/}"
-        TAG="${{ matrix.platform.os }}-${ARCH}"
+        TAG="${{ matrix.platform }}-${{ matrix.arch }}"
         echo "tag=${TAG}" | tee -a $GITHUB_OUTPUT
         echo "image=ghcr.io/${{ github.repository }}/base-${{ matrix.base_image_vsn }}:${TAG}" | tee -a $GITHUB_OUTPUT
     - uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
@@ -204,7 +166,7 @@ jobs:
       with:
         pull: true
         no-cache: true
-        platforms: ${{ matrix.platform.arch }}
+        platforms: linux/${{ matrix.arch }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
           BUILD_FROM=${{ steps.base_tag.outputs.image }}
@@ -222,7 +184,7 @@ jobs:
       with:
         pull: true
         no-cache: true
-        platforms: ${{ matrix.platform.arch }}
+        platforms: linux/${{ matrix.arch }}
         build-args: |
           BUILD_FROM=${{ steps.base_tag.outputs.image }}
           OTP_VERSION=${{ matrix.otp }}
@@ -247,10 +209,10 @@ jobs:
     - name: Upload digest
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
-        name: "digests-${{ matrix.platform.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ matrix.platform.arch == 'linux/amd64' && 'amd64' || 'arm64' }}"
+        name: "digests-${{ matrix.platform }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ matrix.arch }}"
         path: /tmp/digests/*
         if-no-files-found: error
-        retention-days: 1
+        retention-days: 7
 
   merge:
     runs-on: ubuntu-latest
@@ -260,7 +222,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.prepare.outputs.final_matrix) }}
+        base_image_vsn:
+          - "5.0"
+        otp: ${{ fromJSON(needs.prepare.outputs.otp) }}
+        elixir: ${{ fromJSON(needs.prepare.outputs.elixir) }}
+        platform:
+          - ubuntu24.04
+          - ubuntu22.04
+          - ubuntu20.04
+          - ubuntu18.04
+          - debian12
+          - debian11
+          - debian10
+          - el9
+          - el8
+          - el7
+          - amzn2
+          - amzn2023
+          - alpine3.15.1
 
     steps:
       - name: Get ref
@@ -273,7 +252,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          pattern: "digests-${{ matrix.platform.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-*"
+          pattern: "digests-${{ matrix.platform }}-${{ matrix.otp }}-${{ matrix.elixir }}-*"
           path: /tmp/digests
           merge-multiple: true
       - name: Set up Docker Buildx
@@ -284,7 +263,7 @@ jobs:
         with:
           images: ${{ steps.registry.outputs.image }}
           tags: |
-            type=raw,value=${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.platform.os }}
+            type=raw,value=${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.platform }}
       - name: Login to Docker Hub
         uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,6 +73,7 @@ jobs:
           - amzn2
           - amzn2023
           - alpine3.15.1
+          - alpine3.21.3
 
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   sanity-checks:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Check workflow files
@@ -26,72 +27,52 @@ jobs:
     needs:
       - sanity-checks
     outputs:
-      matrix: ${{ steps.versions.outputs.matrix }}
+      otp: ${{ steps.versions.outputs.otp }}
+      elixir: ${{ steps.versions.outputs.elixir }}
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-    - name: get release versions
+    - name: Get target OTP and Elixir versions
       id: versions
       run: |
         #!/bin/bash
         versions="$(grep -E "^\+\sOTP-.*" ./RELEASE.md | \
           sed -E 's/\+\sOTP-([0-9.-]*),Elixir-([0-9.]*).*/{"otp":"\1","elixir":"\2"}/g' | \
           jq -sc .)"
-
-        platforms='[
-          {"os": "ubuntu24.04", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "ubuntu24.04", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "ubuntu22.04", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "ubuntu22.04", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "ubuntu20.04", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "ubuntu20.04", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "ubuntu18.04", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "ubuntu18.04", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "debian12", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "debian12", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "debian11", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "debian11", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "debian10", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "debian10", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "el9", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "el9", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "el8", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "el8", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "el7", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "el7", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "amzn2", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "amzn2", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "amzn2023", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "amzn2023", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]},
-          {"os": "alpine3.15.1", "arch": "linux/amd64", "runner": ["self-hosted", "linux", "x64", "ephemeral"]},
-          {"os": "alpine3.15.1", "arch": "linux/arm64", "runner": ["self-hosted", "linux", "arm64", "ephemeral"]}
-        ]'
-
-        matrix="$(jq -cn \
-          --argjson versions "$versions" \
-          --argjson platforms "$platforms" \
-          '[
-            $versions[] as $version |
-            $platforms[] as $platform |
-            {
-              base_image_vsn: "5.0",
-              otp: $version.otp,
-              elixir: $version.elixir,
-              platform: $platform
-            }
-          ]')"
-
-        echo "matrix=$matrix" | tee -a $GITHUB_OUTPUT
+        echo "$versions"
+        echo "otp=$(echo "$versions" | jq -r '.[].otp' | jq -Rsc 'split("\n")[:-1]')" | tee -a $GITHUB_OUTPUT
+        echo "elixir=$(echo "$versions" | jq -r '.[].elixir' | jq -Rsc 'split("\n")[:-1]')" | tee -a $GITHUB_OUTPUT
 
   build:
-    name: ${{ matrix.platform.os }} ${{ matrix.platform.arch }} OTP-${{ matrix.otp }} Elixir-${{ matrix.elixir }}
-    runs-on: ${{ github.repository_owner == 'emqx' && matrix.platform.runner || 'ubuntu-latest' }}
+    name: ${{ matrix.platform }} ${{ matrix.arch }} OTP-${{ matrix.otp }} Elixir-${{ matrix.elixir }}
+    runs-on: ${{ github.repository_owner == 'emqx' && format('aws-ubuntu22.04-{0}', matrix.arch) || (matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04') }}
+
     needs:
       - prepare
 
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+        base_image_vsn:
+          - "5.0"
+        otp: ${{ fromJSON(needs.prepare.outputs.otp) }}
+        elixir: ${{ fromJSON(needs.prepare.outputs.elixir) }}
+        arch:
+          - amd64
+          - arm64
+        platform:
+          - ubuntu24.04
+          - ubuntu22.04
+          - ubuntu20.04
+          - ubuntu18.04
+          - debian12
+          - debian11
+          - debian10
+          - el9
+          - el8
+          - el7
+          - amzn2
+          - amzn2023
+          - alpine3.15.1
 
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -108,9 +89,7 @@ jobs:
     - name: define base tag
       id: base_tag
       run: |
-        PLATFORM=${{ matrix.platform.arch }}
-        ARCH="${PLATFORM#linux/}"
-        TAG="${{ matrix.platform.os }}-${ARCH}"
+        TAG="${{ matrix.platform }}-${{ matrix.arch }}"
         echo "tag=${TAG}" | tee -a $GITHUB_OUTPUT
         echo "image=ghcr.io/${{ github.repository }}/base-${{ matrix.base_image_vsn }}:${TAG}" | tee -a $GITHUB_OUTPUT
     - name: Get cache
@@ -122,7 +101,7 @@ jobs:
     - uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
       if: ${{ startsWith(matrix.otp, '24') }}
       with:
-        platforms: ${{ matrix.platform.arch }}
+        platforms: linux/${{ matrix.arch }}
         cache-from: type=local,src=/tmp/.docker-buildx-cache,mode=max
         build-args: |
           BUILD_FROM=${{ steps.base_tag.outputs.image }}
@@ -136,7 +115,7 @@ jobs:
     - uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
       if: ${{ ! startsWith(matrix.otp, '24') }}
       with:
-        platforms: ${{ matrix.platform.arch }}
+        platforms: "linux/${{ matrix.arch }}"
         cache-from: type=local,src=/tmp/.docker-buildx-cache,mode=max
         build-args: |
           BUILD_FROM=${{ steps.base_tag.outputs.image }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,8 +27,7 @@ jobs:
     needs:
       - sanity-checks
     outputs:
-      otp: ${{ steps.versions.outputs.otp }}
-      elixir: ${{ steps.versions.outputs.elixir }}
+      matrix: ${{ steps.versions.outputs.matrix }}
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
     - name: Get target OTP and Elixir versions
@@ -38,9 +37,43 @@ jobs:
         versions="$(grep -E "^\+\sOTP-.*" ./RELEASE.md | \
           sed -E 's/\+\sOTP-([0-9.-]*),Elixir-([0-9.]*).*/{"otp":"\1","elixir":"\2"}/g' | \
           jq -sc .)"
-        echo "$versions"
-        echo "otp=$(echo "$versions" | jq -r '.[].otp' | jq -Rsc 'split("\n")[:-1]')" | tee -a $GITHUB_OUTPUT
-        echo "elixir=$(echo "$versions" | jq -r '.[].elixir' | jq -Rsc 'split("\n")[:-1]')" | tee -a $GITHUB_OUTPUT
+
+        platforms='[
+          "ubuntu24.04",
+          "ubuntu22.04",
+          "ubuntu20.04",
+          "ubuntu18.04",
+          "debian12",   
+          "debian11",   
+          "debian10",   
+          "el9",        
+          "el8",        
+          "el7",         
+          "amzn2",      
+          "amzn2023",   
+          "alpine3.15.1",
+          "alpine3.21.3"
+        ]'
+
+        arhitectures='["amd64", "arm64"]'
+
+        matrix="$(jq -cn \
+          --argjson versions "$versions" \
+          --argjson platforms "$platforms" \
+          --argjson arhitectures "$arhitectures" \
+          '[
+            $versions[] as $version |
+            $platforms[] as $platform |
+            $arhitectures[] as $arch |
+            {
+              base_image_vsn: "5.0",
+              otp: $version.otp,
+              elixir: $version.elixir,
+              platform: $platform,
+              arch: $arch
+            }
+          ]')"
+        echo "matrix=$matrix" | tee -a $GITHUB_OUTPUT
 
   build:
     name: ${{ matrix.platform }} ${{ matrix.arch }} OTP-${{ matrix.otp }} Elixir-${{ matrix.elixir }}
@@ -52,28 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image_vsn:
-          - "5.0"
-        otp: ${{ fromJSON(needs.prepare.outputs.otp) }}
-        elixir: ${{ fromJSON(needs.prepare.outputs.elixir) }}
-        arch:
-          - amd64
-          - arm64
-        platform:
-          - ubuntu24.04
-          - ubuntu22.04
-          - ubuntu20.04
-          - ubuntu18.04
-          - debian12
-          - debian11
-          - debian10
-          - el9
-          - el8
-          - el7
-          - amzn2
-          - amzn2023
-          - alpine3.15.1
-          - alpine3.21.3
+        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
 
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGES = alpine3.15 amzn2 amzn2023 debian10 debian11 debian12 el7 el8 el9 ubuntu18.04 ubuntu20.04 ubuntu22.04 ubuntu24.04
+IMAGES = alpine3.15.1 alpine3.21.3 amzn2 amzn2023 debian10 debian11 debian12 el7 el8 el9 ubuntu18.04 ubuntu20.04 ubuntu22.04 ubuntu24.04
 
 .PHONY: all
 all: $(IMAGES)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,4 @@ List per major version used by EMQX, quic, rocksdb builds
 OTP version from emqx/otp.git, Elixir version from elixir-lang/elixir.git.
 
 + OTP-24.3.4.2-4,Elixir-1.15.7
-+ OTP-25.3.2-2,Elixir-1.15.7
-+ OTP-26.2.5.2-3,Elixir-1.15.7
 + OTP-27.2-2,Elixir-1.17.3

--- a/alpine3.21.3/Dockerfile
+++ b/alpine3.21.3/Dockerfile
@@ -1,0 +1,50 @@
+ARG BUILD_FROM=public.ecr.aws/docker/library/alpine:3.21.3
+FROM ${BUILD_FROM}
+
+RUN apk add --no-cache --virtual .build-deps \
+                autoconf \
+                automake \
+                bash \
+                bison \
+                bsd-compat-headers \
+                ca-certificates \
+                coreutils \
+                curl \
+                cyrus-sasl-dev \
+                cyrus-sasl-gssapiv2 \
+                dpkg-dev dpkg \
+                flex \
+                g++ \
+                gcc \
+                git \
+                jq \
+                krb5 \
+                krb5-dev \
+                krb5-libs \
+                libc-dev \
+                libffi-dev \
+                libsasl \
+                libtool \
+                linux-headers \
+                lksctp-tools-dev \
+                make \
+                ncurses-dev \
+                openjdk8 \
+                openssh-client \
+                openssh-keygen \
+                openssl-dev \
+                py3-pip \
+                python3 \
+                tar \
+                unixodbc-dev \
+                wget \
+                zip \
+                zlib-dev \
+                krb5-server \
+                expect
+
+
+COPY get-cmake.sh /get-cmake.sh
+RUN /get-cmake.sh build
+
+CMD [ "/bin/sh" ]


### PR DESCRIPTION
Add latest alpine version to use as a base in 4.4. The version that is used now has a critical unpatched vulnerability.