### PR TITLE
chore: bump otp -> 27.2-3 and elixir -> 1.18.3

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,4 +3,4 @@ List per major version used by EMQX, quic, rocksdb builds
 OTP version from emqx/otp.git, Elixir version from elixir-lang/elixir.git.
 
 + OTP-24.3.4.2-4,Elixir-1.15.7
-+ OTP-27.2-3,Elixir-1.17.3
++ OTP-27.2-3,Elixir-1.18.3

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,4 +3,4 @@ List per major version used by EMQX, quic, rocksdb builds
 OTP version from emqx/otp.git, Elixir version from elixir-lang/elixir.git.
 
 + OTP-24.3.4.2-4,Elixir-1.15.7
-+ OTP-27.2-2,Elixir-1.17.3
++ OTP-27.2-3,Elixir-1.17.3


### PR DESCRIPTION
Basically to grab https://github.com/emqx/otp/pull/69